### PR TITLE
[nginx] Remove systemd override for nginx.service

### DIFF
--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -61,8 +61,10 @@
     path: '/etc/systemd/system/nginx.service.d'
     state: 'directory'
     mode: '0755'
-  when: (nginx__deploy_state in ['present', 'config'] and
-         ansible_service_mgr == 'systemd')
+  when: nginx__deploy_state in ['present', 'config'] and
+        ansible_service_mgr == 'systemd' and
+        ansible_distribution_release in ["stretch", "buster", "bullseye",
+          "trusty", "xenial", "bionic", "focal", "jammy", "lunar"]
 
 - name: Create systemd override configuration for nginx unit
   ansible.builtin.template:
@@ -70,8 +72,26 @@
     dest: '/etc/systemd/system/nginx.service.d/wait-for-network.conf'
     mode: '0644'
   notify: [ 'Reload systemd daemon' ]
-  when: (nginx__deploy_state in ['present', 'config'] and
-         ansible_service_mgr == 'systemd')
+  when: nginx__deploy_state in ['present', 'config'] and
+        ansible_service_mgr == 'systemd' and
+        ansible_distribution_release in ["stretch", "buster", "bullseye",
+          "trusty", "xenial", "bionic", "focal", "jammy", "lunar"]
+
+- name: Remove systemd override configuration for nginx unit
+  ansible.builtin.file:
+    path: '/etc/systemd/system/nginx.service.d/wait-for-network.conf'
+    state: 'absent'
+  notify: [ 'Reload systemd daemon' ]
+  when: ansible_distribution_release not in ["stretch", "buster", "bullseye",
+          "trusty", "xenial", "bionic", "focal", "jammy", "lunar"]
+
+- name: Remove systemd override directory for nginx unit, if empty
+  ansible.builtin.command: 'rmdir /etc/systemd/system/nginx.service.d/'
+  register: nginx__register_rmdir_systemd
+  changed_when: nginx__register_rmdir_systemd.rc == 0
+  failed_when: False
+  when: ansible_distribution_release not in ["stretch", "buster", "bullseye",
+          "trusty", "xenial", "bionic", "focal", "jammy", "lunar"]
 
 - name: Make sure that Ansible local facts directory is present
   ansible.builtin.file:

--- a/ansible/roles/nginx/templates/etc/systemd/system/nginx.service.d/wait-for-network.conf.j2
+++ b/ansible/roles/nginx/templates/etc/systemd/system/nginx.service.d/wait-for-network.conf.j2
@@ -12,6 +12,9 @@
 # This also fixes issues with IPv6 enabled hosts where IPv6 addresses might not
 # be configured at the time 'nginx' is started.
 # Ref: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=861261
+#
+# Note that this is the default since Debian package version 1.22.0-2,
+# i.e. Debian Bookworm/Ubuntu Mantic or later.
 
 [Unit]
 After=network-online.target


### PR DESCRIPTION
Since Debian package version 1.22.0-2 (Bookworm, Mantic), the nginx.service unit has been updated to make "After=network-online.target" the default, making this override unnecessary.